### PR TITLE
Update golem-js, normalize approach to errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
     "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended"
   ],
+  "ignorePatterns": ["dist"],
   "overrides": [
     {
       "env": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -33,7 +33,6 @@
     }
   },
   "rules": {
-    "prettier/prettier": "error",
-    "@typescript-eslint/no-explicit-any": "warn"
+    "prettier/prettier": "error"
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -32,6 +32,7 @@
     }
   },
   "rules": {
-    "prettier/prettier": "warn"
+    "prettier/prettier": "error",
+    "@typescript-eslint/no-explicit-any": "warn"
   }
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "tabWidth": 2,
-  "useTabs": false,
-  "semi": true
-}

--- a/examples/react-with-vite/src/run-task/ImageClassification.tsx
+++ b/examples/react-with-vite/src/run-task/ImageClassification.tsx
@@ -37,13 +37,13 @@ async function classifyOnGolem(
   const input = `/golem/input/img.${extension}`;
   const output = `/golem/output/out.json`;
   const imageData = await readFile(image);
+
   await runFunction(async (ctx) => {
     await ctx.uploadData(imageData, input);
     await ctx.run(`node index.js ${input} ${output}`);
     const result = await ctx.downloadData(output);
     const decoder = new TextDecoder();
-    const resultJson = JSON.parse(decoder.decode(result.data));
-    return resultJson;
+    return JSON.parse(decoder.decode(result.data));
   });
 }
 
@@ -57,7 +57,7 @@ export default function ImageClassification({
   const [image, setImage] = useState<File | null>(null);
   const [imgSrc, setImgSrc] = useState<string | null>(null);
 
-  const { run, isError, isRunning, result } = useTask(executor);
+  const { run, error, isRunning, result } = useTask(executor);
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files) {
@@ -97,7 +97,7 @@ export default function ImageClassification({
         {isResultDefinedAndValid(result) && (
           <div className="max-w-sm">
             This image is a{" "}
-            <span className="font-bold">{result.className} </span>
+            <span className="font-bold">{result.className}</span>
             with a probability of{" "}
             <span className="font-bold">
               {new Decimal(result.probability).mul(100).toFixed(2)}%
@@ -121,7 +121,11 @@ export default function ImageClassification({
           </button>
         </div>
       </form>
-      {isError && <p className="badge badge-error">Something went wrong</p>}
+      {error && (
+        <p className="badge badge-error">
+          Task failed due to {error.toString()}
+        </p>
+      )}
     </div>
   );
 }

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -19,10 +19,12 @@ export type YagnaProviderConfig = {
 
 /**
  * Provides context for all hooks that interact with Yagna.
+ *
  * @param config - The configuration object for the provider.
  * @param config.yagnaAppKey - The API key for the Yagna client. This is required.
  * @param config.yagnaUrl - The base URL for the Yagna client. This is optional and defaults to "http://127.0.0.1:7465".
  * @param config.swrKey - The key used to prefix all SWR cache keys. This is optional and defaults to "golem-sdk".
+ *
  * @example
  * ```
  * <YagnaProvider config={{ yagnaAppKey: "myApiKey", yagnaUrl: "http://localhost:7465" }}>

--- a/packages/react/src/useDebitNotes.ts
+++ b/packages/react/src/useDebitNotes.ts
@@ -11,6 +11,7 @@ import { useConfig } from "./useConfig";
  * @param {number} [options.limit] - The maximum number of debit notes to fetch.
  * @param {SWRConfiguration} [options.swrConfig] - Configuration options for the underlying SWR hook.
  * @returns An object containing the fetched debit notes, loading and validation states, error state, and a function to refetch the data.
+ *
  * @example
  * ```jsx
  * function MyComponent() {
@@ -48,6 +49,7 @@ export function useDebitNotes({
   swrConfig?: SWRConfiguration;
 } = {}) {
   const { yagnaClient, swrKey } = useConfig();
+
   const { data, isLoading, isValidating, error, mutate } = useSWR(
     [swrKey, "debit-notes", limit],
     async () => {
@@ -66,6 +68,7 @@ export function useDebitNotes({
       ...swrConfig,
     },
   );
+
   return {
     debitNotes: data,
     isLoading,

--- a/packages/react/src/useExecutor.ts
+++ b/packages/react/src/useExecutor.ts
@@ -1,6 +1,7 @@
 import { ExecutorOptions, TaskExecutor } from "@golem-sdk/golem-js";
 import { useConfig } from "./useConfig";
-import { useState, useCallback } from "react";
+import { useCallback, useState } from "react";
+
 export { TaskExecutor };
 export type { ExecutorOptions };
 
@@ -37,7 +38,7 @@ export function useExecutor(
   const [executor, setExecutor] = useState<TaskExecutor | null>(null);
   const [isInitializing, setIsInitializing] = useState(false);
   const [isTerminating, setIsTerminating] = useState(false);
-  const [error, setError] = useState<any>(null);
+  const [error, setError] = useState<Error>();
   const config = useConfig();
   const isInitialized = !!executor;
 
@@ -70,9 +71,13 @@ export function useExecutor(
         ...options,
       });
       setExecutor(executor);
-      setError(null);
-    } catch (e) {
-      setError(e);
+      setError(undefined);
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err);
+      } else {
+        setError(new Error(JSON.stringify(err)));
+      }
       removeBeforeUnloadHandler();
     } finally {
       setIsInitializing(false);

--- a/packages/react/src/useExecutor.ts
+++ b/packages/react/src/useExecutor.ts
@@ -37,7 +37,7 @@ export function useExecutor(
   const [executor, setExecutor] = useState<TaskExecutor | null>(null);
   const [isInitializing, setIsInitializing] = useState(false);
   const [isTerminating, setIsTerminating] = useState(false);
-  const [error, setError] = useState<unknown>(null);
+  const [error, setError] = useState<any>(null);
   const config = useConfig();
   const isInitialized = !!executor;
 

--- a/packages/react/src/useHandleDebitNote.ts
+++ b/packages/react/src/useHandleDebitNote.ts
@@ -9,15 +9,17 @@ interface Options {
 
 /**
  * A hook that handles the acceptance of a debit note.
+ *
  * @param debitNote - The debit note to be accepted.
  * @param options - An optional object containing the following properties:
- * @param options.onAccepted: A function to be called when the debit note is accepted (for example to show a success message to the user).
- * @param options.onRejected: A function to be called when the debit note is rejected (for example to show an error message to the user).
- * @param options.allocationTimeoutMs: The timeout for the allocation in milliseconds (defaults to 60 seconds).
+ * @param options.onAccepted -  A function to be called when the debit note is accepted (for example to show a success message to the user).
+ * @param options.onRejected - A function to be called when the debit note is rejected (for example to show an error message to the user).
+ * @param options.allocationTimeoutMs - The timeout for the allocation in milliseconds (defaults to 60 seconds).
+ *
  * @returns An object containing the following properties:
  *   - acceptDebitNote: A function that accepts the debit note.
  *   - isLoading: A boolean indicating whether the hook is currently loading.
- *   - isError: A boolean indicating whether an error occurred while accepting the debit note.
+ *   - error: Error that occurred while accepting the debit note.
  *   - isAccepted: A boolean indicating whether the debit note was accepted.
  */
 export function useHandleDebitNote(
@@ -26,12 +28,12 @@ export function useHandleDebitNote(
 ) {
   const { yagnaClient } = useConfig();
   const [isLoading, setIsLoading] = useState(false);
-  const [isError, setIsError] = useState(false);
   const [isAccepted, setIsAccepted] = useState(false);
+  const [error, setError] = useState<Error>();
 
   const reset = useCallback(() => {
     setIsLoading(false);
-    setIsError(false);
+    setError(undefined);
     setIsAccepted(false);
   }, []);
 
@@ -67,8 +69,12 @@ export function useHandleDebitNote(
       });
       setIsAccepted(true);
       onAccepted?.();
-    } catch (e) {
-      setIsError(true);
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err);
+      } else {
+        setError(new Error(JSON.stringify(err)));
+      }
       onRejected?.();
     } finally {
       setIsLoading(false);
@@ -78,7 +84,7 @@ export function useHandleDebitNote(
   return {
     acceptDebitNote,
     isLoading,
-    isError,
     isAccepted,
+    error,
   };
 }

--- a/packages/react/src/useTask.ts
+++ b/packages/react/src/useTask.ts
@@ -17,7 +17,7 @@ export type { Worker };
  * - `isError`: A boolean indicating whether an error occurred while running the task.
  * - `result`: The result of the task, if it has finished running.
  * - `run`: A function that can be called to run the task.
- * - `error`: The error that has occurred - undefined otherwise.
+ * - `error`: The error that has occurred - null otherwise.
  *
  * @example
  * ```jsx
@@ -44,7 +44,7 @@ export function useTask<T = any>(executor: TaskExecutor) {
   const [isRunning, setIsRunning] = React.useState(false);
   const [isError, setIsError] = React.useState(false);
   const [result, setResult] = React.useState<T>();
-  const [error, setError] = React.useState<any>();
+  const [error, setError] = React.useState<any>(null);
 
   const run = React.useCallback(
     async (worker: Worker<any, T>) => {

--- a/packages/react/src/useTask.ts
+++ b/packages/react/src/useTask.ts
@@ -1,5 +1,5 @@
 import { TaskExecutor } from "@golem-sdk/golem-js";
-import React from "react";
+import { useCallback, useState } from "react";
 
 // TODO: expose worker type in @golem-sdk/golem-js
 // Import for use in the hook
@@ -14,15 +14,14 @@ export type { Worker };
  *
  * @returns An object containing the following properties:
  * - `isRunning`: A boolean indicating whether the task is currently running.
- * - `isError`: A boolean indicating whether an error occurred while running the task.
  * - `result`: The result of the task, if it has finished running.
  * - `run`: A function that can be called to run the task.
- * - `error`: The error that has occurred - null otherwise.
+ * - `error`: The error that has occurred - undefined otherwise.
  *
  * @example
  * ```jsx
  * function MyComponent({ executor }) {
- *   const { isRunning, isError, result, run } = useTask(executor);
+ *   const { isRunning, error, result, run } = useTask(executor);
  *   const onClick = () =>
  *     run(async (ctx) => {
  *       return (await ctx.run("echo", ["Hello world!"])).stdout;
@@ -33,38 +32,36 @@ export type { Worker };
  *         Run task
  *       </button>
  *       {isRunning && <div>Task is running...</div>}
- *       {isError && <div>Task failed</div>}
+ *       {error && <div>Task failed due to: {error}</div>}
  *       {result && <div>Task result: {result}</div>}
  *     </div>
  *   );
  * }
  * ```
  */
-export function useTask<T = any>(executor: TaskExecutor) {
-  const [isRunning, setIsRunning] = React.useState(false);
-  const [result, setResult] = React.useState<T>();
-  const [error, setError] = React.useState<any>(null);
+export function useTask<TData = unknown>(executor: TaskExecutor) {
+  const [isRunning, setIsRunning] = useState(false);
+  const [result, setResult] = useState<TData>();
+  const [error, setError] = useState<Error>();
 
-  /**
-   * @deprecated This property is deprecated and will be removed in the next major version. Check for `error` instead.
-   */
-  const [isError, setIsError] = React.useState(false);
-
-  const run = React.useCallback(
-    async (worker: Worker<any, T>) => {
+  const run = useCallback(
+    async (worker: Worker<unknown, TData>) => {
       if (isRunning) {
         throw new Error("Task is already running");
       }
+
       setIsRunning(true);
-      setIsError(false);
       setResult(undefined);
 
       try {
-        const result = await executor.run<T>(worker);
+        const result = await executor.run<TData>(worker);
         setResult(result);
-      } catch (err: any) {
-        setError(err);
-        setIsError(true);
+      } catch (err) {
+        if (err instanceof Error) {
+          setError(err);
+        } else {
+          setError(new Error(JSON.stringify(err)));
+        }
       } finally {
         setIsRunning(false);
       }
@@ -74,7 +71,6 @@ export function useTask<T = any>(executor: TaskExecutor) {
 
   return {
     isRunning,
-    isError,
     result,
     run,
     error,

--- a/packages/react/src/useTask.ts
+++ b/packages/react/src/useTask.ts
@@ -42,9 +42,13 @@ export type { Worker };
  */
 export function useTask<T = any>(executor: TaskExecutor) {
   const [isRunning, setIsRunning] = React.useState(false);
-  const [isError, setIsError] = React.useState(false);
   const [result, setResult] = React.useState<T>();
   const [error, setError] = React.useState<any>(null);
+
+  /**
+   * @deprecated This property is deprecated and will be removed in the next major version. Check for `error` instead.
+   */
+  const [isError, setIsError] = React.useState(false);
 
   const run = React.useCallback(
     async (worker: Worker<any, T>) => {


### PR DESCRIPTION
This PR addresses few things:

- updates the golem-js to the most recent version
- drops support for `isError` property returned from hooks
- adds support for `error` property which will return `Error|undefined` to be consistent across all hooks (breaking change)